### PR TITLE
feat(`freebsd`, `macos`): install OpenJDK 8 and configure it for running Clouseau

### DIFF
--- a/freebsd/playbook/freebsd.yml
+++ b/freebsd/playbook/freebsd.yml
@@ -54,6 +54,11 @@
       name: openjdk11-jre
       state: present
 
+  - name: install OpenJDK 8
+    ansible.builtin.package:
+      name: openjdk8-jre
+      state: present
+
   - name: install runit
     ansible.builtin.package:
       name: runit
@@ -99,6 +104,18 @@
     user:
       name: jenkins
       system: true
+
+  - name: configure OpenJDK 8 for Clouseau
+    block:
+      - name: configure csh
+        lineinfile:
+          path: /etc/csh.cshrc
+          line: setenv CLOUSEAU_JAVA_HOME /usr/local/openjdk8
+
+      - name: configure sh
+        lineinfile:
+          path: /etc/profile
+          line: export CLOUSEAU_JAVA_HOME=/usr/local/openjdk8
 
   - name: set up runit - create service dir
     file:

--- a/freebsd/playbook/freebsd.yml
+++ b/freebsd/playbook/freebsd.yml
@@ -105,18 +105,6 @@
       name: jenkins
       system: true
 
-  - name: configure OpenJDK 8 for Clouseau
-    block:
-      - name: configure csh
-        lineinfile:
-          path: /etc/csh.cshrc
-          line: setenv CLOUSEAU_JAVA_HOME /usr/local/openjdk8
-
-      - name: configure sh
-        lineinfile:
-          path: /etc/profile
-          line: export CLOUSEAU_JAVA_HOME=/usr/local/openjdk8
-
   - name: set up runit - create service dir
     file:
       state: directory

--- a/macos/playbook/macos.yml
+++ b/macos/playbook/macos.yml
@@ -48,6 +48,26 @@
       name: 'openjdk@11'
       state: present
 
+  - name: install OpenJDK 8
+    block:
+      - name: fetch distribution
+        get_url:
+          url: https://cdn.azul.com/zulu/bin/zulu8.74.0.17-ca-jre8.0.392-macosx_aarch64.tar.gz
+          dest: /tmp/openjdk8.tgz
+
+      - name: unpack distribution
+        unarchive:
+          src: /tmp/openjdk8.tgz
+          dest: /opt/java/openjdk8
+          extra_opts:
+            - --strip-component 1
+        creates: /opt/java/openjdk8
+
+      - name: remove distribution
+        file:
+          dest: /tmp/openjdk8.tgz
+          state: absent
+
   - name: brew link openjdk force
     command: /opt/homebrew/bin/brew link openjdk@11 --force
     args:
@@ -77,6 +97,11 @@
       shell: /bin/zsh
       password: "{{ jenkins_pw }}"
       system: true
+
+  - name: configure OpenJDK 8 for Clouseau
+    lineinfile:
+      path: /Users/jenkins2/.zshenv
+      line: export CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
 
   - name: create LaunchDaemons dir
     file:

--- a/macos/playbook/macos.yml
+++ b/macos/playbook/macos.yml
@@ -98,11 +98,6 @@
       password: "{{ jenkins_pw }}"
       system: true
 
-  - name: configure OpenJDK 8 for Clouseau
-    lineinfile:
-      path: /Users/jenkins2/.zshenv
-      line: export CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
-
   - name: create LaunchDaemons dir
     file:
       state: directory


### PR DESCRIPTION
Make it possible for the macOS and FreeBSD CI workers to run the integration tests with Clouseau.  This is a follow-up for [`apache/couchdb` #4835](https://github.com/apache/couchdb/pull/4835).

*Note:* I have not tested these changes so there are no guarantees that they are going to work.  But hopefully they are not that far from the right solution.