### PR TITLE
Fix permitrootlogin

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,12 +17,12 @@
     name: root
     password_lock: true
 
-- name: Disable root login vis ssh
+- name: Disable root login with a password
   become: yes
   lineinfile:
     dest: /etc/ssh/sshd_config
     regexp: '^(#\s*)?#PermitRootLogin'
-    line: "PermitRootLogin no"
+    line: "PermitRootLogin prohibit-password"
     state: present
   notify: restart sshd
 


### PR DESCRIPTION
Some instances need root login, but allow it only for pk, no passwords.